### PR TITLE
Added a <div> as parent element for Then/Else

### DIFF
--- a/src/ReactIf.js
+++ b/src/ReactIf.js
@@ -5,8 +5,8 @@ function render(props) {
   if (typeof props.children === 'function') {
     return props.children();
   }
-
-  return props.children || null;
+  
+  return React.createElement('div', null, props.children) || null;
 }
 
 export function Then(props) {


### PR DESCRIPTION
Issue #13
This will wrap siblings without parents in a 'div' in order to stop React from giving errors. This issue is still open in React (https://github.com/facebook/react/issues/2127) and I guess this is the only way for now.
